### PR TITLE
Demo User Buttons

### DIFF
--- a/client/src/helpers/demovalues.ts
+++ b/client/src/helpers/demovalues.ts
@@ -1,0 +1,5 @@
+export const demoValues = {
+  username: 'demo',
+  email: 'demo@tattooart.com',
+  password: 'demo123',
+};

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -6,6 +6,7 @@ import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import { CircularProgress } from '@material-ui/core';
+import { demoValues } from '../../../helpers/demovalues';
 
 interface Props {
   handleSubmit: (
@@ -26,13 +27,9 @@ interface Props {
   ) => void;
 }
 
-// function setDemoValues({values}) {
-//   values.email = 'demo@tattooart.com';
-//   values.password = 'demo123';
-// }
-
 export default function Login({ handleSubmit }: Props): JSX.Element {
   const classes = useStyles();
+  let demo = false;
 
   return (
     <Formik
@@ -91,7 +88,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
           />
           <Box textAlign="center">
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
+              {!demo && isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
             </Button>
             <Button
               type="submit"
@@ -100,11 +97,12 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
               color="primary"
               className={classes.submit}
               onClick={() => {
-                values.email = 'demo@tattooart.com';
-                values.password = 'demo123';
+                values.email = demoValues.email;
+                values.password = demoValues.password;
+                demo = true;
               }}
             >
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Use Demo'}
+              {demo && isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Use Demo'}
             </Button>
           </Box>
           <div style={{ height: 95 }} />

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -26,6 +26,11 @@ interface Props {
   ) => void;
 }
 
+// function setDemoValues({values}) {
+//   values.email = 'demo@tattooart.com';
+//   values.password = 'demo123';
+// }
+
 export default function Login({ handleSubmit }: Props): JSX.Element {
   const classes = useStyles();
 
@@ -87,6 +92,19 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
           <Box textAlign="center">
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
+            </Button>
+            <Button
+              type="submit"
+              size="large"
+              variant="contained"
+              color="primary"
+              className={classes.submit}
+              onClick={() => {
+                values.email = 'demo@tattooart.com';
+                values.password = 'demo123';
+              }}
+            >
+              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Use Demo'}
             </Button>
           </Box>
           <div style={{ height: 95 }} />

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -111,6 +111,9 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
             </Button>
+            <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
+              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Use Demo'}
+            </Button>
           </Box>
         </form>
       )}

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -9,6 +9,7 @@ import { CircularProgress } from '@material-ui/core';
 import { demoValues } from '../../../helpers/demovalues';
 import login from '../../../helpers/APICalls/login';
 import { useAuth } from '../../../context/useAuthContext';
+import { useSnackBar } from '../../../context/useSnackbarContext';
 
 interface Props {
   handleSubmit: (
@@ -35,12 +36,19 @@ interface Props {
 const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
   const classes = useStyles();
   const { updateLoginContext } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
   let demo = false;
   const demoLogin = () => {
     login(demoValues.email, demoValues.password).then((data) => {
-      if (data.success) {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
         updateLoginContext(data.success);
         demo = true;
+      } else {
+        // Catchall for unknown issues
+        console.error({ data });
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
       }
     });
   };

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -6,6 +6,9 @@ import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import { CircularProgress } from '@material-ui/core';
+import { demoValues } from '../../../helpers/demovalues';
+import login from '../../../helpers/APICalls/login';
+import { useAuth } from '../../../context/useAuthContext';
 
 interface Props {
   handleSubmit: (
@@ -31,6 +34,16 @@ interface Props {
 
 const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
   const classes = useStyles();
+  const { updateLoginContext } = useAuth();
+  let demo = false;
+  const demoLogin = () => {
+    login(demoValues.email, demoValues.password).then((data) => {
+      if (data.success) {
+        updateLoginContext(data.success);
+        demo = true;
+      }
+    });
+  };
 
   return (
     <Formik
@@ -109,10 +122,18 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
 
           <Box textAlign="center">
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
+              {!demo && isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
             </Button>
-            <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Use Demo'}
+            <Button
+              // disables formik validation
+              type="button"
+              size="large"
+              variant="contained"
+              color="primary"
+              className={classes.submit}
+              onClick={demoLogin}
+            >
+              {demo ? <CircularProgress style={{ color: 'white' }} /> : 'Use Demo'}
             </Button>
           </Box>
         </form>


### PR DESCRIPTION
### What this PR does (required):
- Adds "Use Demo" Buttons to Login and Signup Page
- Defines demo user credentials
- Sets user details to the demo user credentials
- Routes user to dashboard

### Screenshots / Videos (required):
- https://user-images.githubusercontent.com/78225194/125495698-b9e31dc0-eda2-4571-b902-e381474660d5.mp4

### Any information needed to test this feature (required):
- Click `Use Demo` in the signup and login page
- Use demo credentials (in `/client/src/helpers/demovalues.ts`) in the login page

### Any issues with the current functionality (optional):
- None
