### PR TITLE
Applied styles to login and signup page

### DIFF
--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -39,18 +39,18 @@ export default function Login(): JSX.Element {
   return (
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
+      <Grid item xs={12} elevation={6} component={Paper} square>
         <Box className={classes.authWrapper}>
-          <AuthHeader linkTo="/signup" asideText="Don't have an account?" btnText="Create account" />
+          <AuthHeader linkTo="/signup" asideText="" btnText="SIGN UP" />
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">
             <Grid container>
-              <Grid item xs>
+              <Grid item xs component={Paper} elevation={3} square className={classes.authCard}>
                 <Typography className={classes.welcome} component="h1" variant="h5">
-                  Welcome back!
+                  Sign in
                 </Typography>
+                <LoginForm handleSubmit={handleSubmit} />
               </Grid>
             </Grid>
-            <LoginForm handleSubmit={handleSubmit} />
           </Box>
           <Box p={1} alignSelf="center" />
         </Box>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -46,11 +46,12 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
+          <label htmlFor="email">{<Typography className={classes.label}>E-mail</Typography>}</label>
           <TextField
             id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
             fullWidth
-            margin="normal"
+            variant="outlined"
+            margin="none"
             InputLabelProps={{
               shrink: true,
             }}
@@ -59,26 +60,28 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             }}
             name="email"
             autoComplete="email"
+            placeholder="Enter e-mail address"
             autoFocus
             helperText={touched.email ? errors.email : ''}
             error={touched.email && Boolean(errors.email)}
             value={values.email}
             onChange={handleChange}
           />
+          <label htmlFor="password">{<Typography className={classes.label}>Password</Typography>}</label>
           <TextField
             id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
             fullWidth
-            margin="normal"
+            variant="outlined"
+            margin="none"
             InputLabelProps={{
               shrink: true,
             }}
             InputProps={{
               classes: { input: classes.inputs },
-              endAdornment: <Typography className={classes.forgot}>Forgot?</Typography>,
             }}
             type="password"
             autoComplete="current-password"
+            placeholder="Enter password"
             helperText={touched.password ? errors.password : ''}
             error={touched.password && Boolean(errors.password)}
             value={values.password}
@@ -86,10 +89,9 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
           />
           <Box textAlign="center">
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
+              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'SIGN IN'}
             </Button>
           </Box>
-          <div style={{ height: 95 }} />
         </form>
       )}
     </Formik>

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -6,14 +6,14 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   label: {
-    fontSize: 19,
+    fontSize: 14,
     color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    marginTop: '15px',
+    fontWeight: 'bold',
   },
   inputs: {
-    marginTop: '.8rem',
+    borderRadius: 0,
     height: '2rem',
-    padding: '5px',
   },
   forgot: {
     paddingRight: 10,
@@ -24,10 +24,10 @@ const useStyles = makeStyles((theme) => ({
     padding: 10,
     width: 160,
     height: 56,
-    borderRadius: theme.shape.borderRadius,
+    borderRadius: 0,
     marginTop: 49,
     fontSize: 16,
-    backgroundColor: '#3a8dff',
+    backgroundColor: '#000',
     fontWeight: 'bold',
   },
 }));

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -9,7 +9,7 @@ const useStyles = makeStyles(() => ({
   },
   authWrapper: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     justifyContent: 'space-between',
     flexDirection: 'column',
     minHeight: '100vh',
@@ -20,7 +20,10 @@ const useStyles = makeStyles(() => ({
     paddingBottom: 20,
     color: '#000000',
     fontWeight: 700,
-    fontFamily: "'Open Sans'",
+    textAlign: 'center',
+  },
+  authCard: {
+    padding: '50px',
   },
 }));
 

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -40,18 +40,18 @@ export default function Register(): JSX.Element {
   return (
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
+      <Grid item xs={12} elevation={6} component={Paper} square>
         <Box className={classes.authWrapper}>
-          <AuthHeader linkTo="/login" asideText="Already have an account?" btnText="Login" />
+          <AuthHeader linkTo="/login" asideText="" btnText="SIGN IN" />
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">
             <Grid container>
-              <Grid item xs>
+              <Grid item xs component={Paper} elevation={3} square className={classes.authCard}>
                 <Typography className={classes.welcome} component="h1" variant="h5">
-                  Create an account
+                  Sign Up
                 </Typography>
+                <SignUpForm handleSubmit={handleSubmit} />
               </Grid>
             </Grid>
-            <SignUpForm handleSubmit={handleSubmit} />
           </Box>
           <Box p={1} alignSelf="center" />
         </Box>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -51,30 +51,12 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
-          <TextField
-            id="username"
-            label={<Typography className={classes.label}>Username</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            name="username"
-            autoComplete="username"
-            autoFocus
-            helperText={touched.username ? errors.username : ''}
-            error={touched.username && Boolean(errors.username)}
-            value={values.username}
-            onChange={handleChange}
-          />
+          <label htmlFor="username">{<Typography className={classes.label}>E-mail</Typography>}</label>
           <TextField
             id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
             fullWidth
-            margin="normal"
+            variant="outlined"
+            margin="none"
             InputLabelProps={{
               shrink: true,
             }}
@@ -83,16 +65,39 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             }}
             name="email"
             autoComplete="email"
+            placeholder="Enter e-mail address"
+            autoFocus
             helperText={touched.email ? errors.email : ''}
             error={touched.email && Boolean(errors.email)}
             value={values.email}
             onChange={handleChange}
           />
+          <label htmlFor="username">{<Typography className={classes.label}>Name</Typography>}</label>
+          <TextField
+            id="username"
+            fullWidth
+            variant="outlined"
+            margin="none"
+            InputLabelProps={{
+              shrink: true,
+            }}
+            InputProps={{
+              classes: { input: classes.inputs },
+            }}
+            name="username"
+            autoComplete="username"
+            placeholder="Enter your name"
+            helperText={touched.username ? errors.username : ''}
+            error={touched.username && Boolean(errors.username)}
+            value={values.username}
+            onChange={handleChange}
+          />
+          <label htmlFor="username">{<Typography className={classes.label}>Password</Typography>}</label>
           <TextField
             id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
             fullWidth
-            margin="normal"
+            variant="outlined"
+            margin="none"
             InputLabelProps={{
               shrink: true,
             }}
@@ -101,15 +106,15 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             }}
             type="password"
             autoComplete="current-password"
+            placeholder="Enter password"
             helperText={touched.password ? errors.password : ''}
             error={touched.password && Boolean(errors.password)}
             value={values.password}
             onChange={handleChange}
           />
-
           <Box textAlign="center">
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
+              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'SIGN UP'}
             </Button>
           </Box>
         </form>

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -6,14 +6,14 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(1),
   },
   label: {
-    fontSize: 19,
+    fontSize: 12,
     color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    marginTop: '15px',
+    fontWeight: 'bold',
   },
   inputs: {
-    marginTop: '.8rem',
+    borderRadius: 0,
     height: '2rem',
-    padding: '5px',
   },
   forgot: {
     paddingRight: 10,
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: theme.shape.borderRadius,
     marginTop: 49,
     fontSize: 16,
-    backgroundColor: '#3a8dff',
+    backgroundColor: '#000',
     fontWeight: 'bold',
   },
 }));

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -20,7 +20,10 @@ const useStyles = makeStyles(() => ({
     paddingBottom: 20,
     color: '#000000',
     fontWeight: 700,
-    fontFamily: "'Open Sans'",
+    textAlign: 'center',
+  },
+  authCard: {
+    padding: '50px',
   },
 }));
 


### PR DESCRIPTION
### What this PR does (required):
- Added styling to login and signup pages

### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/62892917/125531802-bdf511c2-0538-459e-9e41-9f3329c3cca1.png)

### Any information needed to test this feature (required):
- Go to your local host (http://localhost:3000/signup)
- You can toggle login/signup using the current nav at the top right

### Any issues with the current functionality (optional):
- padding of the "Paper" component surrounding the forms is not perfect
- input fields have a border-radius that intermittently displays.  Coded for 0 border-radius but it does not seem to work
- mouseover of buttons and focus of inputs are the default UI blue

