### PR TITLE
Add Protected Routes Component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Dashboard from './pages/Dashboard/Dashboard';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
+import ProtectedRoute from './components/ProtectedRoutes/ProtectedRoutes';
 
 import './App.css';
 
@@ -20,9 +21,7 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard">
-                  <Dashboard />
-                </Route>
+                <ProtectedRoute exact path="/dashboard" component={Dashboard} />
                 <Route path="*">
                   <Redirect to="/login" />
                 </Route>

--- a/client/src/components/ProtectedRoutes/ProtectedRoutes.tsx
+++ b/client/src/components/ProtectedRoutes/ProtectedRoutes.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Route, Redirect, RouteProps } from 'react-router-dom';
+import { useAuth } from '../../context/useAuthContext';
+
+interface Props extends RouteProps {
+  component: React.ComponentType;
+}
+
+const ProtectedRoute = ({ component: Component, ...rest }: Props): JSX.Element => {
+  const { loggedInUser } = useAuth();
+  return (
+    <Route
+      render={(props) => (loggedInUser ? <Component {...rest} {...props} /> : <Redirect to="/login" />)}
+      {...rest}
+    />
+  );
+};
+export default ProtectedRoute;


### PR DESCRIPTION
### What this PR does (required):
- Enables setting routes as accessible only if logged in

### Screenshots / Videos (required):
- ![protected](https://user-images.githubusercontent.com/78225194/125532341-1aef120b-8d82-42f9-8f30-f631cb5e828c.gif)


### Any information needed to test this feature (required):
- Access `/dashboard` while logged out

### Any issues with the current functionality (optional):
- Other protected routes such as `/contest`, `/profile` not yet set up
