### PR TITLE
Hotfix navbar links

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,7 +33,7 @@ function App(): JSX.Element {
               {/* Replace the components once created */}
               <ProtectedRoute exact path="/messages" component={Dashboard} />
               <ProtectedRoute exact path="/notifications" component={Dashboard} />
-              <ProtectedRoute exact path="/new-contest" component={Dashboard} />
+              <ProtectedRoute exact path="/new-contest" component={NewContest} />
               <ProtectedRoute exact path="/profile" component={ProfileSetting} />
               <ProtectedRoute exact path="/logout" component={Dashboard} />
               <Route path="*">

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -3,6 +3,7 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
+import { Link as RouterLink } from 'react-router-dom';
 import Avatar from '@material-ui/core/Avatar';
 import Logo from '../../Images/logo.png';
 import demoProfilePhoto from '../../Images/demo-profile-photo.png';
@@ -22,24 +23,24 @@ const NavBar = (): JSX.Element => {
         <div style={{ width: '100%' }}>
           <Box display="flex" flexWrap="nowrap" p={1} m={1} alignItems="center" bgcolor="transparent">
             <Box p={1} flexGrow={1}>
-              <Link href="/">
+              <Link component={RouterLink} to="/">
                 <img width="170px" src={Logo} alt="Tattoo Art logo" />
               </Link>
             </Box>
             {loggedInUser ? (
               <>
                 <Box p={0}>
-                  <Link variant="subtitle1" className={classes.link} href="/">
+                  <Link component={RouterLink} variant="subtitle1" className={classes.link} to="/">
                     Discover
                   </Link>
                 </Box>
                 <Box p={0}>
-                  <Link variant="subtitle1" className={classes.link} href="/messages">
+                  <Link component={RouterLink} variant="subtitle1" className={classes.link} to="/messages">
                     Messages
                   </Link>
                 </Box>
                 <Box p={0}>
-                  <Link variant="subtitle1" className={classes.link} href="/notifications">
+                  <Link component={RouterLink} variant="subtitle1" className={classes.link} to="/notifications">
                     Notifications
                   </Link>
                 </Box>
@@ -64,7 +65,7 @@ const NavBar = (): JSX.Element => {
                 </Box>
                 <Box p={0}>
                   {/* replace `Kenneth` with username */}
-                  <Link variant="subtitle1" className={classes.username} href="/profile">
+                  <Link component={RouterLink} variant="subtitle1" className={classes.username} to="/profile">
                     Kenneth
                   </Link>
                 </Box>


### PR DESCRIPTION
### What this PR does (required):
- Uses from Link from `react-router-dom` to fix redirects when using links in the navbar
- Loads correct component for `/new-contest` link
- 
### Screenshots / Videos (required):
https://user-images.githubusercontent.com/78225194/126216551-e81668ec-c1ce-4f0f-b23e-a7adf93d2cbc.mp4

### Any information needed to test this feature (required):
- Click links on navbar (Messages, Notifications, Profile) to test whether they still redirect to `/dashboard`

### Any issues with the current functionality (optional):
- None
