### PR TITLE
Added Profile page with current and past contests

### DIFF
--- a/client/src/components/ContestItem/ContestItem.tsx
+++ b/client/src/components/ContestItem/ContestItem.tsx
@@ -1,0 +1,44 @@
+import { FC } from 'react';
+import { Button, Grid, Box, ImageList, ImageListItem, ImageListItemBar } from '@material-ui/core';
+import useStyles from './useStyles';
+
+interface Props {
+  imgSrc: string;
+  imgCount: number;
+  headline: string;
+  byline: string;
+  prizeAmt: number;
+  completed?: boolean;
+}
+
+const ContestItem: FC<Props> = ({
+  imgSrc,
+  imgCount,
+  headline,
+  byline,
+  prizeAmt,
+  completed = false,
+}: Props): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <Grid container className={classes.contestItemContainer}>
+      <Grid item>
+        <ImageList cols={1}>
+          <ImageListItem key={1}>
+            <img src={imgSrc} alt={headline} className={classes.contestImg} />
+            <ImageListItemBar title={imgCount + ' SKETCH' + (imgCount > 1 ? 'ES' : '')} />
+          </ImageListItem>
+        </ImageList>
+      </Grid>
+      <Grid item className={classes.infoContainer}>
+        <Box className={classes.headline}>{headline}</Box>
+        <Box className={classes.byline}>{byline}</Box>
+        <Box>
+          <Button className={classes.btn}>{completed ? 'COMPLETED' : `$${prizeAmt}`}</Button>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ContestItem;

--- a/client/src/components/ContestItem/useStyles.ts
+++ b/client/src/components/ContestItem/useStyles.ts
@@ -1,0 +1,38 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  contestItemContainer: {
+    marginBottom: 25,
+  },
+  contestImg: {
+    //width: 150,
+    //height: 150,
+  },
+  infoContainer: {
+    textAlign: 'left',
+    margin: '25px 0 25px 40px',
+  },
+  headline: {
+    color: '#000',
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  byline: {
+    color: '#999',
+    fontSize: 12,
+    marginTop: '10px',
+  },
+  btn: {
+    margin: theme.spacing(3, 0, 2),
+    padding: 10,
+    color: '#fff',
+    height: 30,
+    borderRadius: 0,
+    marginTop: 25,
+    fontSize: 12,
+    backgroundColor: '#000',
+    fontWeight: 'bold',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/ProfileSetting/Profile/Profile.tsx
+++ b/client/src/pages/ProfileSetting/Profile/Profile.tsx
@@ -1,0 +1,115 @@
+import { FC, useState } from 'react';
+import { useAuth } from '../../../context/useAuthContext';
+import ContestItem from '../../../components/ContestItem/ContestItem';
+import { Button, Grid, Box, Tabs, Tab, Avatar, Typography } from '@material-ui/core';
+import demoProfilePhoto from '../../../Images/demo-profile-photo.png';
+import mockContestPic from '../../../Images/68f55f7799df6c8078a874cfe0a61a5e6e9e1687.png';
+import useStyles from './useStyles';
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  dir?: string;
+  index: number;
+  value: number;
+}
+const TabPanel = (props: TabPanelProps) => {
+  const { children, value, index, ...other } = props;
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`full-width-tabpanel-${index}`}
+      aria-labelledby={`full-width-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box p={3}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+};
+
+const mockContests = [
+  {
+    imgSrc: mockContestPic,
+    imgCount: 25,
+    headline: 'Lion tattoo concept in minimal style',
+    byline: 'Looking for a cool simple ideas',
+    prizeAmt: 150,
+  },
+  {
+    imgSrc: mockContestPic,
+    imgCount: 9,
+    headline: 'Anchors, like all the pirates',
+    byline: 'Artistic anchors or anchor related art',
+    prizeAmt: 75,
+  },
+];
+
+const Profile: FC = (): JSX.Element => {
+  const classes = useStyles();
+  const { loggedInUser } = useAuth();
+  const [value, setValue] = useState(0);
+
+  const handleChange = (event: React.ChangeEvent<unknown>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Grid container direction="column" className={classes.profileContainer}>
+      <Grid xs={12} md={10} item className={classes.avatarContainer}>
+        <Box textAlign="center">
+          <Avatar className={classes.profileImg} src={demoProfilePhoto} alt="Profile Photo" />
+          <Typography className={classes.name}>Kenneth Stewart</Typography>
+          <Button size="large" variant="contained" color="primary" className={classes.btn}>
+            Edit profile
+          </Button>
+        </Box>
+      </Grid>
+      <Grid xs={12} md={10} item className={classes.tabsContainer}>
+        <Box textAlign="center">
+          <Tabs
+            value={value}
+            variant="fullWidth"
+            onChange={handleChange}
+            indicatorColor="primary"
+            textColor="primary"
+            centered
+          >
+            <Tab label="IN PROGRESS" />
+            <Tab label="COMPLETED" />
+          </Tabs>
+          <TabPanel value={value} index={0}>
+            {mockContests.map((contest, index) => (
+              <ContestItem
+                key={`activeContest-${index}`}
+                imgSrc={contest.imgSrc}
+                imgCount={contest.imgCount}
+                headline={contest.headline}
+                byline={contest.byline}
+                prizeAmt={contest.prizeAmt}
+              />
+            ))}
+          </TabPanel>
+          <TabPanel value={value} index={1}>
+            {mockContests.map((contest, index) => (
+              <ContestItem
+                key={`activeContest-${index}`}
+                imgSrc={contest.imgSrc}
+                imgCount={contest.imgCount}
+                headline={contest.headline}
+                byline={contest.byline}
+                prizeAmt={contest.prizeAmt}
+                completed
+              />
+            ))}
+          </TabPanel>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Profile;

--- a/client/src/pages/ProfileSetting/Profile/useStyles.ts
+++ b/client/src/pages/ProfileSetting/Profile/useStyles.ts
@@ -1,0 +1,40 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  btn: {
+    margin: theme.spacing(3, 2, 2),
+    padding: 10,
+    width: 80,
+    height: 30,
+    borderRadius: 0,
+    marginTop: 25,
+    fontSize: 9,
+    backgroundColor: '#000',
+    fontWeight: 'bold',
+  },
+  profileContainer: {
+    marginTop: 35,
+  },
+  avatarContainer: {
+    width: '100%',
+    margin: 'auto',
+  },
+  tabsContainer: {
+    width: '100%',
+    margin: '55px auto',
+  },
+  name: {
+    color: '#000',
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginTop: 10,
+  },
+  profileImg: {
+    width: theme.spacing(10),
+    height: theme.spacing(10),
+    display: 'block',
+    margin: 'auto',
+  },
+}));
+
+export default useStyles;

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -1,6 +1,6 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
   typography: {
     fontFamily: '"Poppins", "sans-serif", "Roboto"',
     fontSize: 12,


### PR DESCRIPTION
### What this PR does (required):
- Mock up for profile page with current and previous contests

### Screenshots / Videos (required):
![profile1](https://user-images.githubusercontent.com/62892917/126790059-d0ee96ee-48a2-4fe7-a806-fc1a8a02369c.PNG)
![profile2](https://user-images.githubusercontent.com/62892917/126790377-cc93474e-1038-4f7b-ac41-756b576371c3.PNG)



### Any information needed to test this feature (required):
- This page is not accessible until the profile settings page is complete 

### Any issues with the current functionality (optional):
- None
