### PR TITLE
Hotfix: Stripe Customer Creation

### DIFF
--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const protect = require('../middleware/auth');
 const {
   getSecret,
-  createCustomerForPayments,
   createSetupIntent,
   listPaymentMethods,
   getPaymentIntent,
@@ -12,8 +11,7 @@ const {
 
 router.route('/').get(protect, listPaymentMethods);
 router.route('/secret').get(protect, getSecret);
-router.route('/customer').post(protect, createCustomerForPayments);
-router.route('/setup-intent').post(protect, createSetupIntent);
+router.route('/setup').post(protect, createSetupIntent);
 router.route('/pay').post(protect, chargeCard);
 
 module.exports = router;

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const protect = require('../middleware/auth');
 const {
   getSecret,
-  setupUserForPayments,
+  createCustomerForPayments,
+  createSetupIntent,
   listPaymentMethods,
   getPaymentIntent,
   chargeCard,
@@ -11,7 +12,8 @@ const {
 
 router.route('/').get(protect, listPaymentMethods);
 router.route('/secret').get(protect, getSecret);
-router.route('/setup').post(protect, setupUserForPayments);
+router.route('/customer').post(protect, createCustomerForPayments);
+router.route('/setup-intent').post(protect, createSetupIntent);
 router.route('/pay').post(protect, chargeCard);
 
 module.exports = router;

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -1,17 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const protect = require('../middleware/auth');
-const {
-  getSecret,
-  createSetupIntent,
-  listPaymentMethods,
-  getPaymentIntent,
-  chargeCard,
-} = require('../controllers/payment');
+const { getSecret, listPaymentMethods, chargeCard } = require('../controllers/payment');
 
 router.route('/').get(protect, listPaymentMethods);
 router.route('/secret').get(protect, getSecret);
-router.route('/setup').post(protect, createSetupIntent);
 router.route('/pay').post(protect, chargeCard);
 
 module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
- Checks whether user has a stripe customer Id
- setupIntent creation triggers customer creation only if the user doesn't have a Stripe Customer Id
-- Multiple setupIntents can be associated to the Stripe Customer Id since setupIntent creation will no longer overwrite existing valid Stripe Customer Id

_This PR shouldn't affect the frontend as there's no APICall by frontend for customer/setupIntent creation yet_

### Screenshots / Videos (required):
https://user-images.githubusercontent.com/78225194/127714113-a3e00e8b-c552-4fac-85b8-edb52993294f.mp4

### Any information needed to test this feature (required):
- Create a setupIntent with a `POST` request to `/payments/setup` where user document has:
-- 1. no stripe id
-- 2. a valid stripe id
-- 3. an incorrect/invalid stripe id

### Any issues with the current functionality (optional):
- `createSetupIntent` may be integrated with `getSecret` so that the secret key is exposed for card confirmation without the front end having to make a separate fetch for getSecret after creating setup intent. This will depend on the workflow (to be discussed).
