### PR TITLE
Hotfix to route customer to payment if winner was already chosen

### DIFF
--- a/client/src/pages/ContestDetails/ContestDetails.tsx
+++ b/client/src/pages/ContestDetails/ContestDetails.tsx
@@ -48,6 +48,12 @@ export default function ContestDetails({ match }: RouteComponentProps): JSX.Elem
     await selectWinner(contestId, submissionId).then((response) => {
       if (response.error) {
         updateSnackBarMessage(response.error);
+        if (response.error === 'A winner for the contest has already been selected.') {
+          setTimeout(function () {
+            history.push(`/contest-details/${contestId}/payment`);
+            return <CircularProgress />;
+          }, 1000);
+        }
       } else {
         updateSnackBarMessage('Winner selected!');
         setTimeout(function () {


### PR DESCRIPTION
### What this PR does (required):
- Routes customer to the payments page if they try to select a winner for a contest where the winner was already chosen.

### Screenshots / Videos (required):
https://user-images.githubusercontent.com/78225194/128515526-6a521811-6891-4c84-8b1a-1f3f93533fe2.mp4

### Any information needed to test this feature (required):
- Tag a winner for a contest, but do not proceed with payment. Go back to the contest and try to select a winner. User is informed that a winner has already been selected then you'll be routed to the payments page.

### Any issues with the current functionality (optional):
- Winning submission not indicated.
