### PR TITLE
Update socketId if user reconnects

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -20,7 +20,6 @@ const notificationRouter = require('./routes/notification');
 const paymentRouter = require('./routes/payment');
 const submissionRouter = require('./routes/submission');
 const emailRouter = require('./routes/email');
-
 const { json, urlencoded } = express;
 require('dotenv').config();
 connectDB();
@@ -39,6 +38,8 @@ const addUser = (email, socketId) => {
   const user = connectedUsers.find((u) => u.email === email);
   if (!user) {
     connectedUsers.push({ email, socketId });
+  } else {
+    user.socketId = socketId;
   }
 };
 


### PR DESCRIPTION
updates connected user record with new socketid

### What this PR does (required):
- Updates the maintained socket IO socketID for a logged in user
- hitting refresh on a page would reconnect to the server,  I was preventing creating more than one connected user record, but not updating the socketId on refresh

### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/62892917/128524152-4abd990e-aeb7-445b-b354-e2c8e40b6201.png)


### Any information needed to test this feature (required):
- messaging should work after a f5 refresh

### Any issues with the current functionality (optional):
- List any problems where you were not able to complete all tasks on ticket
- List any problems this PR may cause for the project or other active PRs
- Post a screenshot/video of the problem, along with detailed console outputs where applicable
