### PR TITLE
Hotfix: Payment Units

### DIFF
--- a/client/src/context/usePaymentsContext.tsx
+++ b/client/src/context/usePaymentsContext.tsx
@@ -1,4 +1,5 @@
 import { useState, useContext, createContext, FunctionComponent, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { IPaymentMethod } from '../interface/Payments';
 
 interface IPaymentMethodContext {
@@ -11,6 +12,7 @@ export const PaymentMethodContext = createContext<IPaymentMethodContext>({
 
 export const PaymentMethodsProvider: FunctionComponent = ({ children }): JSX.Element => {
   const [paymentMethods, setPaymentMethods] = useState<IPaymentMethod[]>([]);
+  const location = useLocation().pathname;
 
   useEffect(() => {
     const getPaymentMethods = async () => {
@@ -20,8 +22,11 @@ export const PaymentMethodsProvider: FunctionComponent = ({ children }): JSX.Ele
         setPaymentMethods(data as IPaymentMethod[]);
       }
     };
-    getPaymentMethods();
-  }, [setPaymentMethods]);
+
+    if (location.endsWith('/profile') || location.endsWith('payment')) {
+      getPaymentMethods();
+    }
+  }, [location]);
 
   return <PaymentMethodContext.Provider value={{ paymentMethods }}>{children}</PaymentMethodContext.Provider>;
 };

--- a/client/src/context/usePaymentsContext.tsx
+++ b/client/src/context/usePaymentsContext.tsx
@@ -26,6 +26,6 @@ export const PaymentMethodsProvider: FunctionComponent = ({ children }): JSX.Ele
   return <PaymentMethodContext.Provider value={{ paymentMethods }}>{children}</PaymentMethodContext.Provider>;
 };
 
-export function useContest(): IPaymentMethodContext {
+export function usePayment(): IPaymentMethodContext {
   return useContext(PaymentMethodContext);
 }

--- a/client/src/pages/ContestPayment/ContestPayment.tsx
+++ b/client/src/pages/ContestPayment/ContestPayment.tsx
@@ -1,17 +1,17 @@
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
-import { PaymentMethodContext } from '../../context/usePaymentsContext';
-import { ContestContext } from '../../context/useContestContext';
+import { usePayment } from '../../context/usePaymentsContext';
+import { useContest } from '../../context/useContestContext';
 import PaymentMethodSelection from './PaymentMethodSelection/PaymentMethodRadio';
 
 export default function ContestPayment({ match }: RouteComponentProps): JSX.Element {
   const classes = useStyles();
   const [contestId, setContestId] = useState<string>('');
-  const { inactiveContests } = useContext(ContestContext);
-  const { paymentMethods } = useContext(PaymentMethodContext);
+  const { inactiveContests } = useContest();
+  const { paymentMethods } = usePayment();
 
   useEffect(() => {
     const params = match.params as { id: string };

--- a/client/src/pages/ContestPayment/PaymentMethodSelection/PaymentMethodRadio.tsx
+++ b/client/src/pages/ContestPayment/PaymentMethodSelection/PaymentMethodRadio.tsx
@@ -30,7 +30,10 @@ export default function PaymentMethodSelection({ paymentMethods, contestId }: Pr
     if (paymentIntentStatus) {
       paymentIntentStatus.status === 'succeeded'
         ? updateSnackBarMessage(
-            `${paymentIntentStatus.currency} ${paymentIntentStatus.amount_received} has been charged from your account.`,
+            // Stripe unit for USD is in cents
+            `${paymentIntentStatus.currency} ${
+              paymentIntentStatus.amount_received / 100
+            } has been charged from your account.`,
           )
         : updateSnackBarMessage(paymentIntentStatus.status);
     } else {

--- a/client/src/pages/ProfileSetting/PaymentDetails/PaymentDetails.tsx
+++ b/client/src/pages/ProfileSetting/PaymentDetails/PaymentDetails.tsx
@@ -23,7 +23,11 @@ const PaymentDetails: FC = (): JSX.Element => {
   return (
     <Elements stripe={stripePromise}>
       <PageContainer titleEl="Payment Details">
-        {paymentMethods ? <PaymentMethods paymentMethods={paymentMethods} /> : <PaymentForm />}
+        {paymentMethods && paymentMethods.length > 0 ? (
+          <PaymentMethods paymentMethods={paymentMethods} />
+        ) : (
+          <PaymentForm />
+        )}
       </PageContainer>
     </Elements>
   );

--- a/server/controllers/payment.js
+++ b/server/controllers/payment.js
@@ -98,7 +98,8 @@ exports.chargeCard = asyncHandler(async (req, res, next) => {
   });
   const paymentIntent = await stripe.paymentIntents.create({
     customer: customerId,
-    amount: prizeAmount,
+    // Stripe unit for USD is in cents
+    amount: prizeAmount * 100,
     currency: 'usd',
     payment_method: cardId,
     confirm: true,


### PR DESCRIPTION
### What this PR does (required):
- Corrects amount charged based on Stripe's basic currency unit for USD, which is in cents. 
- Fixes payments form not rendering when payment methods list is empty
- Specifies paths that check payment methods. Fixes premature check resulting in empty payment methods array.
*Previously, passing in the prize amount will charge the card in cents (ex: Prize is $100, Charged amount is only $1.00). Ref: [Stripe PaymentIntent API](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-amount)*

### Screenshots / Videos (required):
https://user-images.githubusercontent.com/78225194/130008113-0b7d8c49-8351-4abd-b120-abbcd69d2db4.mp4

### Any information needed to test this feature (required):
- Select a winner for a contest past its deadline. 
- Check that payment method list is displayed then select card.
- Check stripe whether amount charged matches the contest prize.

### Any issues with the current functionality (optional):
- N/A
