### PR TITLE
Feature: Add payments gate for creating contests

### DIFF
--- a/client/src/context/usePaymentsContext.tsx
+++ b/client/src/context/usePaymentsContext.tsx
@@ -23,7 +23,7 @@ export const PaymentMethodsProvider: FunctionComponent = ({ children }): JSX.Ele
       }
     };
 
-    if (location.endsWith('/profile') || location.endsWith('payment')) {
+    if (location.endsWith('/profile') || location.endsWith('payment') || location.endsWith('/new-contest')) {
       getPaymentMethods();
     }
   }, [location]);

--- a/client/src/pages/Contest/NewContest.tsx
+++ b/client/src/pages/Contest/NewContest.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import { useHistory } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
@@ -8,10 +9,18 @@ import useStyles from './useStyles';
 import NewContestForm from './NewContestForm/NewContestForm';
 import { createContestAPI } from '../../helpers/APICalls/contest';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import { usePayment } from '../../context/usePaymentsContext';
 
 const NewContest: FunctionComponent = (): JSX.Element => {
   const classes = useStyles();
+  const history = useHistory();
   const { updateSnackBarMessage } = useSnackBar();
+  const { paymentMethods } = usePayment();
+
+  if (paymentMethods.length === 0) {
+    updateSnackBarMessage('Please add a payment method before creating contests');
+    history.push('/profile');
+  }
 
   const handleSubmit = (
     {

--- a/client/src/pages/ContestPayment/ContestPayment.tsx
+++ b/client/src/pages/ContestPayment/ContestPayment.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps, useHistory } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
+import { useSnackBar } from '../../context/useSnackbarContext';
 import { usePayment } from '../../context/usePaymentsContext';
 import { useContest } from '../../context/useContestContext';
 import PaymentMethodSelection from './PaymentMethodSelection/PaymentMethodRadio';
@@ -12,6 +13,13 @@ export default function ContestPayment({ match }: RouteComponentProps): JSX.Elem
   const [contestId, setContestId] = useState<string>('');
   const { inactiveContests } = useContest();
   const { paymentMethods } = usePayment();
+  const history = useHistory();
+  const { updateSnackBarMessage } = useSnackBar();
+
+  if (paymentMethods.length === 0) {
+    updateSnackBarMessage('Please add a payment method.');
+    history.push('/profile');
+  }
 
   useEffect(() => {
     const params = match.params as { id: string };


### PR DESCRIPTION
### What this PR does (required):
- Reroutes user to the Settings page when they try to select a winner or create a contest if they don't have a payment method.

### Screenshots / Videos (required):
https://user-images.githubusercontent.com/78225194/130026773-9dd4b306-e687-40ea-a59e-762a5b26acac.mp4

### Any information needed to test this feature (required):
- Remove payment information from the user in the database. 
- Select a winner for an expired contest. This should reroute to the Settings page.
- Click `Create Contest` in the Navbar. This should reroute to the Settings page.

### Any issues with the current functionality (optional):
None.