### PR TITLE
Feature: Condense message notifications

### DIFF
--- a/server/controllers/notification.js
+++ b/server/controllers/notification.js
@@ -72,6 +72,9 @@ module.exports.socketCreateNotification = function (socket, connectedUsers) {
       }
 
       const notification = await Notification.create(params);
+      if (notification && params.type === 'message') {
+        await Notification.deleteMany({ type: 'message', senderId: params.senderId, _id: { $ne: notification._id } });
+      }
 
       if (!notification) {
         throw new Error('Invalid notification data');


### PR DESCRIPTION
### What this PR does (required):
- Condenses message notifications to one notification only per sender
*Multiple submission notifications per sender is allowed as submissions may be different files.*

### Screenshots / Videos (required):
https://user-images.githubusercontent.com/78225194/130179410-690bf7b4-6fd0-4e5e-9e4f-1a355e767075.mp4

### Any information needed to test this feature (required):
- Send multiple messages from one account to the same receiver. 
- Check receiver's account for message notifications. Should only have one notification from sender.
- Check that submission notifications from sender are not deleted.

### Any issues with the current functionality (optional):
None
